### PR TITLE
fix stale webpack finds and ConsoleJanitor patch

### DIFF
--- a/src/api/ContextMenus.tsx
+++ b/src/api/ContextMenus.tsx
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { DropdownMenuItem } from "@components";
+import {
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuSub,
+    DropdownMenuSubContent,
+    DropdownMenuSubTrigger,
+} from "@components";
 import { ErrorBoundary } from "@components/ErrorBoundary";
 import { React } from "@turbopack/common/react";
 import { createExternalStore, mapGetOrCreate, sortedEntries } from "@utils/misc";
@@ -26,6 +32,45 @@ export interface ContextMenuItemDef<L extends ContextMenuLocation = ContextMenuL
     render?: ComponentType<ContextMenuLocationMap[L]>;
     onSelect?: (ctx: ContextMenuLocationMap[L]) => void;
 }
+
+export interface MenuPrimitives {
+    Item: ComponentType<any>;
+    Sub: ComponentType<any>;
+    SubTrigger: ComponentType<any>;
+    SubContent: ComponentType<any>;
+    Separator: ComponentType<any>;
+}
+
+let menuPrimitivesContext: React.Context<MenuPrimitives | null> | null = null;
+function getMenuPrimitivesContext(): React.Context<MenuPrimitives | null> {
+    return menuPrimitivesContext ??= React.createContext<MenuPrimitives | null>(null);
+}
+
+function useMenuPrimitive<K extends keyof MenuPrimitives>(key: K, fallback: MenuPrimitives[K]): MenuPrimitives[K] {
+    const ctx = React.useContext(getMenuPrimitivesContext());
+    return ctx?.[key] ?? fallback;
+}
+
+export const MenuItem: ComponentType<any> = props => {
+    const C = useMenuPrimitive("Item", DropdownMenuItem);
+    return <C {...props} />;
+};
+export const MenuSub: ComponentType<any> = props => {
+    const C = useMenuPrimitive("Sub", DropdownMenuSub);
+    return <C {...props} />;
+};
+export const MenuSubTrigger: ComponentType<any> = props => {
+    const C = useMenuPrimitive("SubTrigger", DropdownMenuSubTrigger);
+    return <C {...props} />;
+};
+export const MenuSubContent: ComponentType<any> = props => {
+    const C = useMenuPrimitive("SubContent", DropdownMenuSubContent);
+    return <C {...props} />;
+};
+export const MenuSeparator: ComponentType<any> = props => {
+    const C = useMenuPrimitive("Separator", DropdownMenuSeparator);
+    return <C {...props} />;
+};
 
 const items = new Map<ContextMenuLocation, Map<string, ContextMenuItemDef<any>>>();
 const store = createExternalStore();
@@ -50,14 +95,14 @@ function renderEntry(def: ContextMenuItemDef<any>, ctx: ContextMenuLocationMap[C
         return <Render {...ctx} />;
     }
     return (
-        <DropdownMenuItem onSelect={() => def.onSelect?.(ctx)}>
+        <MenuItem onSelect={() => def.onSelect?.(ctx)}>
             {resolveLazyNode(def.icon)}
             {resolveLazyNode(def.label)}
-        </DropdownMenuItem>
+        </MenuItem>
     );
 }
 
-export function VoidContextMenuItems<L extends ContextMenuLocation>({ location, ...ctx }: { location: L } & ContextMenuLocationMap[L]): ReactNode {
+export function VoidContextMenuItems<L extends ContextMenuLocation>({ location, menu, ...ctx }: { location: L; menu?: MenuPrimitives } & ContextMenuLocationMap[L]): ReactNode {
     useExternalStore(store);
 
     const map = items.get(location);
@@ -65,7 +110,7 @@ export function VoidContextMenuItems<L extends ContextMenuLocation>({ location, 
 
     const sorted = sortedEntries(map);
 
-    return (
+    const content = (
         <>
             {sorted.map(([id, def]) => (
                 <ErrorBoundary key={id} fallback={null}>
@@ -74,4 +119,10 @@ export function VoidContextMenuItems<L extends ContextMenuLocation>({ location, 
             ))}
         </>
     );
+
+    if (menu) {
+        const Ctx = getMenuPrimitivesContext();
+        return <Ctx.Provider value={menu}>{content}</Ctx.Provider>;
+    }
+    return content;
 }

--- a/src/plugins/_api/contextMenu/index.tsx
+++ b/src/plugins/_api/contextMenu/index.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { type ContextMenuLocation, VoidContextMenuItems } from "@api/ContextMenus";
+import { type ContextMenuLocation, type MenuPrimitives, VoidContextMenuItems } from "@api/ContextMenus";
 import { ErrorBoundary } from "@components/ErrorBoundary";
 import { React } from "@turbopack/common/react";
 import { Devs } from "@utils/constants";
@@ -17,10 +17,10 @@ export default definePlugin({
     required: true,
     hidden: true,
 
-    renderItems(location: ContextMenuLocation, ctx?: Record<string, any>) {
+    renderItems(location: ContextMenuLocation, ctx?: Record<string, any>, menu?: MenuPrimitives) {
         return (
             <ErrorBoundary>
-                <VoidContextMenuItems location={location} {...ctx} />
+                <VoidContextMenuItems location={location} menu={menu} {...ctx} />
             </ErrorBoundary>
         );
     },
@@ -40,8 +40,12 @@ export default definePlugin({
                     replace: "onEditClick:$1,id:arguments[0].id,route:$2})",
                 },
                 {
+                    match: /Item:(\i)\.(Dropdown|Context)MenuItem,/g,
+                    replace: "$&VoidMenu:{Item:$1.$2MenuItem,Sub:$1.$2MenuSub,SubTrigger:$1.$2MenuSubTrigger,SubContent:$1.$2MenuSubContent,Separator:$1.$2MenuSeparator},",
+                },
+                {
                     match: /(\i)&&\(0,\i\.jsxs?\)\(\i,\{onSelect:\(\)=>\1\(\),className:"gap-2",children:\[\(0,\i\.jsx\)\(\i\.TrashIcon,.{0,80}\]\}\)/,
-                    replace: '$self.renderItems("conversation",{conversationId:arguments[0].id}),$&',
+                    replace: '$self.renderItems("conversation",{conversationId:arguments[0].id},arguments[0].VoidMenu),$&',
                 },
             ],
         },

--- a/src/plugins/_core/settings/index.tsx
+++ b/src/plugins/_core/settings/index.tsx
@@ -32,7 +32,7 @@ import type { ComponentType, ReactNode } from "react";
 
 const logger = new Logger("Settings");
 
-const GhostIcon = findExportedComponentLazy("GhostIcon");
+const MoonIcon = findExportedComponentLazy("MoonIcon");
 
 const cl = classNameFactory("void-settings-");
 
@@ -171,7 +171,7 @@ function VoidMenu() {
     return (
         <DropdownMenuSub>
             <DropdownMenuSubTrigger>
-                <GhostIcon className={cl("menu-icon")} />
+                <MoonIcon className={cl("menu-icon")} />
                 Void
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>

--- a/src/plugins/accountSwitcher.extension/index.tsx
+++ b/src/plugins/accountSwitcher.extension/index.tsx
@@ -31,6 +31,7 @@ const cl = classNameFactory("void-as-");
 const UsersIcon = findExportedComponentLazy("UsersIcon");
 const CheckIcon = findExportedComponentLazy("CheckIcon");
 const PlusIcon = findExportedComponentLazy("PlusIcon");
+const RefreshCwIcon = findExportedComponentLazy("RefreshCwIcon");
 
 const AVATAR_FETCH_TIMEOUT_MS = 4000;
 const AVATAR_MAX_BYTES = 256 * 1024;
@@ -277,7 +278,7 @@ function AccountMenu() {
                 <DropdownMenuSubContent className={cl("content")}>
                     {accounts.length > 0 && (
                         <div className={cl("heading")}>
-                            <Text as="span" size="xs" color="secondary">Saved accounts</Text>
+                            <Text as="span" size="xs" color="secondary">Saved Accounts</Text>
                         </div>
                     )}
                     {accounts.map(a => (
@@ -291,7 +292,7 @@ function AccountMenu() {
                     ))}
                     {accounts.length > 0 && <DropdownMenuSeparator />}
                     <DropdownMenuItem onSelect={() => user && void saveCurrent(user)} disabled={!user} className={cl("save")}>
-                        <PlusIcon className={cl("icon-lead")} />
+                        {hasCurrent ? <RefreshCwIcon className={cl("icon-lead")} /> : <PlusIcon className={cl("icon-lead")} />}
                         <Text as="span" size="sm">{hasCurrent ? "Update current account" : "Save current account"}</Text>
                     </DropdownMenuItem>
                 </DropdownMenuSubContent>

--- a/src/plugins/cloneChats/index.tsx
+++ b/src/plugins/cloneChats/index.tsx
@@ -6,8 +6,7 @@
 
 import "./styles.css";
 
-import type { ContextMenuLocationMap } from "@api/ContextMenus";
-import { DropdownMenuItem } from "@components";
+import { type ContextMenuLocationMap, MenuItem } from "@api/ContextMenus";
 import { ErrorBoundary } from "@components/ErrorBoundary";
 import { CopyIcon } from "@components/icons";
 import { React } from "@turbopack/common/react";
@@ -45,10 +44,10 @@ function CloneItem({ conversationId }: ContextMenuLocationMap["conversation"]) {
     const streaming = useIsStreaming(conversationId);
 
     return (
-        <DropdownMenuItem onSelect={() => cloneChat(conversationId).catch(e => logger.error("Failed to clone chat:", e))} disabled={streaming}>
+        <MenuItem onSelect={() => cloneChat(conversationId).catch(e => logger.error("Failed to clone chat:", e))} disabled={streaming}>
             <CopyIcon size={16} className="void-clone-icon" />
             Clone
-        </DropdownMenuItem>
+        </MenuItem>
     );
 }
 

--- a/src/plugins/consoleJanitor/index.ts
+++ b/src/plugins/consoleJanitor/index.ts
@@ -18,7 +18,7 @@ export default definePlugin({
         { find: "x.ai/careers", replacement: { match: /console\.info\("[^"]{0,2000}"\)/, replace: "void 0" } },
         { find: "useDrawerContext must be used within a Drawer.Root", all: true, replacement: warnNoop },
         { find: 'displayName="DialogFooter"', all: true, replacement: warnNoop },
-        { find: "pressure_observer", replacement: { match: /"PressureObserver"in window/, replace: "false" } },
+        { find: "pressure_observer", replacement: { match: /if\(!window\.PressureObserver\)return/, replace: "return" } },
         { find: "NO_I18NEXT_INSTANCE", all: true, replacement: { match: /console\.warn\(\.\.\.\i\)/, replace: "void 0" } },
     ],
 });

--- a/src/plugins/customInstructions/index.tsx
+++ b/src/plugins/customInstructions/index.tsx
@@ -6,15 +6,11 @@
 
 import "./styles.css";
 
-import type { ContextMenuLocationMap } from "@api/ContextMenus";
+import { type ContextMenuLocationMap, MenuItem, MenuSub, MenuSubContent, MenuSubTrigger } from "@api/ContextMenus";
 import { definePluginSettings } from "@api/Settings";
 import {
     Button,
     ButtonWithTooltip,
-    DropdownMenuItem,
-    DropdownMenuSub,
-    DropdownMenuSubContent,
-    DropdownMenuSubTrigger,
     Text,
     Textarea,
 } from "@components";
@@ -183,23 +179,23 @@ function InstructionsMenu({ conversationId }: ContextMenuLocationMap["conversati
     if (!presets.length) return null;
 
     return (
-        <DropdownMenuSub>
-            <DropdownMenuSubTrigger className={cl("trigger")}>
+        <MenuSub>
+            <MenuSubTrigger className={cl("trigger")}>
                 <BookIcon size={16} /> Instructions
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent>
-                <DropdownMenuItem onSelect={() => assign()} className={cl("menu-item")}>
+            </MenuSubTrigger>
+            <MenuSubContent>
+                <MenuItem onSelect={() => assign()} className={cl("menu-item")}>
                     <Text size="sm">None</Text>
                     {!activePresetId && <CheckIcon className="size-3.5 shrink-0" />}
-                </DropdownMenuItem>
+                </MenuItem>
                 {presets.map(p => (
-                    <DropdownMenuItem key={p.id} onSelect={() => assign(p.id)} className={cl("menu-item")}>
+                    <MenuItem key={p.id} onSelect={() => assign(p.id)} className={cl("menu-item")}>
                         <Text size="sm">{p.name || "Untitled"}</Text>
                         {activePresetId === p.id && <CheckIcon className="size-3.5 shrink-0" />}
-                    </DropdownMenuItem>
+                    </MenuItem>
                 ))}
-            </DropdownMenuSubContent>
-        </DropdownMenuSub>
+            </MenuSubContent>
+        </MenuSub>
     );
 }
 

--- a/src/plugins/exportChat/index.tsx
+++ b/src/plugins/exportChat/index.tsx
@@ -6,13 +6,7 @@
 
 import "./styles.css";
 
-import type { ContextMenuLocationMap } from "@api/ContextMenus";
-import {
-    DropdownMenuItem,
-    DropdownMenuSub,
-    DropdownMenuSubContent,
-    DropdownMenuSubTrigger,
-} from "@components";
+import { type ContextMenuLocationMap, MenuItem, MenuSub, MenuSubContent, MenuSubTrigger } from "@api/ContextMenus";
 import { ErrorBoundary } from "@components/ErrorBoundary";
 import { DownloadIcon } from "@components/icons";
 import type { GrokResponse } from "@grok-types";
@@ -201,19 +195,19 @@ function ExportMenu({ conversationId }: ContextMenuLocationMap["conversation"]) 
     const streaming = useIsStreaming(conversationId);
 
     return (
-        <DropdownMenuSub>
-            <DropdownMenuSubTrigger disabled={streaming} className="void-export-trigger">
+        <MenuSub>
+            <MenuSubTrigger disabled={streaming} className="void-export-trigger">
                 <DownloadIcon size={16} className="void-export-icon" />
                 Export
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent>
+            </MenuSubTrigger>
+            <MenuSubContent>
                 {FORMATS.map(({ fmt, label }) => (
-                    <DropdownMenuItem key={fmt} onSelect={() => exportChat(conversationId, fmt).catch(e => logger.error("Failed to export chat", e))}>
+                    <MenuItem key={fmt} onSelect={() => exportChat(conversationId, fmt).catch(e => logger.error("Failed to export chat", e))}>
                         {label}
-                    </DropdownMenuItem>
+                    </MenuItem>
                 ))}
-            </DropdownMenuSubContent>
-        </DropdownMenuSub>
+            </MenuSubContent>
+        </MenuSub>
     );
 }
 

--- a/src/turbopack/common/utils.ts
+++ b/src/turbopack/common/utils.ts
@@ -42,5 +42,4 @@ export const ClassNames: {
 
 export const FileUtils: {
     downloadBlob: (blob: Blob, filename: string) => Promise<void>;
-    downloadUri: (url: string, filename: string) => Promise<void>;
-} = findByPropsLazy("downloadBlob", "downloadUri");
+} = findByPropsLazy("downloadBlob", "extractFiles");


### PR DESCRIPTION
## Fixed
- **ConsoleJanitor** pressure_observer patch — old match `"PressureObserver"in window` gone, now `if(!window.PressureObserver)return` → `return`
- **FileUtils** find — module exports `downloadBlob`+`extractFiles`, not `downloadUri`. drop unused `downloadUri` type
- **Settings** menu icon — `GhostIcon` not loaded in current bundle, swap to `MoonIcon`

## Verified
- ConsoleJanitor patch validated against module 49691 via void-mcp
- `MoonIcon` confirmed present in module 578901
- oxlint + tsc clean

do not merge — waiting on ai reviews

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken context menu items after upstream menu changes by adding menu primitive adapters and wiring them through the plugin API. Also updates the ConsoleJanitor `pressure_observer` patch and corrects the `FileUtils` lookup, plus small UI tweaks.

- **Bug Fixes**
  - Context menu: introduce `MenuPrimitives` adapters (`MenuItem`, `MenuSub`, `MenuSubTrigger`, `MenuSubContent`, `MenuSeparator`) and provide them via context; pass host primitives through `_api/contextMenu`; update `cloneChats`, `customInstructions`, and `exportChat` to use the adapters so items and submenus render correctly.
  - ConsoleJanitor: update `pressure_observer` patch to match new runtime (`if(!window.PressureObserver)return` → `return`).
  - Utils: fix `FileUtils` finder to `findByPropsLazy("downloadBlob", "extractFiles")` and drop unused `downloadUri` type.
  - Settings: replace missing `GhostIcon` with `MoonIcon`.
  - Account Switcher: title-case "Saved Accounts" and use `RefreshCwIcon` when updating the current account.

<sup>Written for commit e1435e104e023dbb230930804e16620a86ee5fe2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

