### PR TITLE
fix stale webpack finds and ConsoleJanitor patch

### DIFF
--- a/src/plugins/_core/settings/index.tsx
+++ b/src/plugins/_core/settings/index.tsx
@@ -32,7 +32,7 @@ import type { ComponentType, ReactNode } from "react";
 
 const logger = new Logger("Settings");
 
-const GhostIcon = findExportedComponentLazy("GhostIcon");
+const MoonIcon = findExportedComponentLazy("MoonIcon");
 
 const cl = classNameFactory("void-settings-");
 
@@ -171,7 +171,7 @@ function VoidMenu() {
     return (
         <DropdownMenuSub>
             <DropdownMenuSubTrigger>
-                <GhostIcon className={cl("menu-icon")} />
+                <MoonIcon className={cl("menu-icon")} />
                 Void
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>

--- a/src/plugins/consoleJanitor/index.ts
+++ b/src/plugins/consoleJanitor/index.ts
@@ -18,7 +18,7 @@ export default definePlugin({
         { find: "x.ai/careers", replacement: { match: /console\.info\("[^"]{0,2000}"\)/, replace: "void 0" } },
         { find: "useDrawerContext must be used within a Drawer.Root", all: true, replacement: warnNoop },
         { find: 'displayName="DialogFooter"', all: true, replacement: warnNoop },
-        { find: "pressure_observer", replacement: { match: /"PressureObserver"in window/, replace: "false" } },
+        { find: "pressure_observer", replacement: { match: /if\(!window\.PressureObserver\)return/, replace: "return" } },
         { find: "NO_I18NEXT_INSTANCE", all: true, replacement: { match: /console\.warn\(\.\.\.\i\)/, replace: "void 0" } },
     ],
 });

--- a/src/turbopack/common/utils.ts
+++ b/src/turbopack/common/utils.ts
@@ -42,5 +42,4 @@ export const ClassNames: {
 
 export const FileUtils: {
     downloadBlob: (blob: Blob, filename: string) => Promise<void>;
-    downloadUri: (url: string, filename: string) => Promise<void>;
-} = findByPropsLazy("downloadBlob", "downloadUri");
+} = findByPropsLazy("downloadBlob", "extractFiles");


### PR DESCRIPTION
## Fixed
- **ConsoleJanitor** pressure_observer patch — old match `\"PressureObserver\"in window` no longer in source, now `if(!window.PressureObserver)return` -> `return`
- **FileUtils** find — module exports `downloadBlob`+`extractFiles`, not `downloadUri`. drop unused `downloadUri` type
- **Settings** menu icon — `GhostIcon` not loaded in current bundle, swap to `MoonIcon`

## Verified
- ConsoleJanitor patch validated against module 49691 via void-mcp
- `MoonIcon` confirmed present in module 578901
- oxlint + tsc clean

do not merge — waiting on ai reviews

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update stale bundle finds and patch logic to match current source, fixing ConsoleJanitor behavior, FileUtils exports, and a missing settings icon.

- **Bug Fixes**
  - ConsoleJanitor: update `pressure_observer` replacement to match `if(!window.PressureObserver)return` → replace with `return`.
  - FileUtils: fix `findByPropsLazy` to use `downloadBlob` and `extractFiles`; remove unused `downloadUri` type.
  - Settings: replace missing `GhostIcon` with `MoonIcon`.

<sup>Written for commit e1435e104e023dbb230930804e16620a86ee5fe2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

