### PR TITLE
fix drifted patches and finders

### DIFF
--- a/reporter/finders.ts
+++ b/reporter/finders.ts
@@ -86,6 +86,7 @@ function moduleMatchesFinder(finder: FinderSpec, mod: ModuleEntry): boolean {
                 const n = a.value;
                 return mod.factory.includes(`"${n}",()=>`)
                     || mod.factory.includes(`"${n}",function`)
+                    || mod.factory.includes(`"${n}",0,`)
                     || mod.factory.includes(`.${n}=`)
                     || mod.factory.includes(`${n}:function`);
             });

--- a/src/plugins/_api/chatBarButtons/index.tsx
+++ b/src/plugins/_api/chatBarButtons/index.tsx
@@ -39,8 +39,8 @@ export default definePlugin({
                     replace: "$&$self.renderButtons(),",
                 },
                 {
-                    match: /paddingInlineEnd:\i\?void 0:(\i)\?/,
-                    replace: "paddingInlineEnd:$1?",
+                    match: /paddingInlineEnd:\i\?void 0:(\i)/,
+                    replace: "paddingInlineEnd:$1",
                 },
             ],
         },

--- a/src/plugins/_api/contextMenu/index.tsx
+++ b/src/plugins/_api/contextMenu/index.tsx
@@ -32,11 +32,11 @@ export default definePlugin({
             group: true,
             replacement: [
                 {
-                    match: /onSaveEdit:(\i),route:(\i)\}\)/,
+                    match: /onSaveEdit:(\i),route:(\i)\}\)(?!\{)/,
                     replace: "onSaveEdit:$1,id:arguments[0].id,route:$2})",
                 },
                 {
-                    match: /onEditClick:(\i),route:(\i)\}\)/g,
+                    match: /onEditClick:(\i),route:(\i)\}\)(?!\{)/g,
                     replace: "onEditClick:$1,id:arguments[0].id,route:$2})",
                 },
                 {

--- a/src/plugins/_core/noTelemetry/index.ts
+++ b/src/plugins/_core/noTelemetry/index.ts
@@ -17,8 +17,8 @@ export default definePlugin({
         {
             find: '"opentelemetry.js.api."',
             replacement: {
-                match: /(\i\.s\(\["onRouterTransitionStart",\(\)=>)\i\],(\d+)\);var/,
-                replace: "$1function(){}],$2);return;var",
+                match: /("onRouterTransitionStart",0,)function\([^)]*\)\{[^}]{0,200}\}/,
+                replace: "$1function(){}",
             },
         },
         {
@@ -30,12 +30,12 @@ export default definePlugin({
                     replace: "$1return}function _ignore(){",
                 },
                 {
-                    match: /function (\i)\(\)\{\i&&\(clearTimeout\(\i\),\i=null\),\i\.default\.set_config\(.{0,120}\),\i\.default\.start_session_recording\(\)\}/,
-                    replace: "function $1(){}",
+                    match: /"startRecordingImagineSession",0,function\(\)\{[\s\S]{0,300}?start_session_recording\(\)\}/,
+                    replace: '"startRecordingImagineSession",0,function(){}',
                 },
                 {
-                    match: /function (\i)\(\)\{\i&&\(clearTimeout\(\i\),\i=null\),\i=setTimeout\(\(\)=>\{\i\.default\.stop_session_recording\(\)\},\d+e?\d*\)\}/,
-                    replace: "function $1(){}",
+                    match: /"stopRecordingImagineSession",0,function\(\)\{[\s\S]{0,300}?stop_session_recording\(\)\},\d+e?\d*\)\}/,
+                    replace: '"stopRecordingImagineSession",0,function(){}',
                 },
             ],
         },
@@ -45,18 +45,21 @@ export default definePlugin({
             group: true,
             replacement: [
                 {
-                    match: /"sendBatchLogEvent",\i=>\{\i\(this\.address\+.{0,40},\i\)\}/,
-                    replace: '"sendBatchLogEvent",()=>{}',
+                    match: /sendBatchLogEvent=\i=>\{[^}]{0,150}\}/,
+                    replace: "sendBatchLogEvent=()=>{}",
                 },
                 {
-                    match: /"sendBatchLogExperimentExposure",\i=>\{\i\(this\.address\+.{0,50},\i\)\}/,
-                    replace: '"sendBatchLogExperimentExposure",()=>{}',
-                },
-                {
-                    match: /"\/api\/log_metric",\i\)/,
-                    replace: '"/api/log_metric",[])',
+                    match: /sendBatchLogExperimentExposure=\i=>\{[^}]{0,150}\}/,
+                    replace: "sendBatchLogExperimentExposure=()=>{}",
                 },
             ],
+        },
+        {
+            find: '"/api/log_metric"',
+            replacement: {
+                match: /"\/api\/log_metric",\i\)/,
+                replace: '"/api/log_metric",[])',
+            },
         },
         {
             find: "isEnvVarsSet(){return void 0!=",

--- a/src/plugins/_core/settings/index.tsx
+++ b/src/plugins/_core/settings/index.tsx
@@ -258,7 +258,7 @@ export default definePlugin({
             },
         },
         {
-            find: 'DialogOverlay",()=>',
+            find: '"DialogOverlay"',
             all: true,
             replacement: {
                 match: /dark:border-border-l1 duration-200/,

--- a/src/plugins/betterImagine/index.tsx
+++ b/src/plugins/betterImagine/index.tsx
@@ -630,8 +630,8 @@ export default definePlugin({
                     replace: ".updateShiftPreview(null))},...$self._hoverProps(),onClick:",
                 },
                 {
-                    match: /if\(((?:\i)&&(?:\i))\)return void (\i)\(e\);(let \i=\{imagine:"home-grid")/,
-                    replace: "if($1||e.ctrlKey||e.metaKey)return void $2(e);$3",
+                    match: /if\(((?:\i)&&(?:\i))\)return void (\i)\((\i)\);(?=(?:let|var|const) \i=\{imagine:"home-grid")/,
+                    replace: "if($1||$3.ctrlKey||$3.metaKey)return void $2($3);",
                 },
             ],
         },
@@ -668,8 +668,9 @@ export default definePlugin({
                     replace: '(0,$1.jsxs)($2.DropdownMenuContent,{align:"end",sideOffset:8,children:[$self._renderUpscaleItem(),$self._renderCopyActions(),',
                 },
                 {
-                    match: /"imagine-"\.concat\((\i)\.slice\(0,8\),"\."\)\.concat\((\i)\?"mp4":"png"\)/,
-                    replace: '($self._buildFilename(e.byId[$1],$2)||"imagine-".concat($1.slice(0,8),".").concat($2?"mp4":"png"))',
+                    match: /`imagine-\$\{(\i)\.slice\(0,8\)\}\.\$\{(\i)\?"mp4":"png"\}`/,
+                    // eslint-disable-next-line no-template-curly-in-string
+                    replace: '($self._buildFilename(e.byId[$1],$2)||`imagine-${$1.slice(0,8)}.${$2?"mp4":"png"}`)',
                 },
             ],
         },

--- a/src/plugins/cleaner/index.ts
+++ b/src/plugins/cleaner/index.ts
@@ -62,27 +62,27 @@ export default definePlugin({
             },
         },
         {
-            find: '"UpsellCard",()=>',
+            find: '"UpsellCard",0,',
             all: true,
             replacement: {
-                match: /"UpsellCard",\(\)=>(\i)/,
-                replace: '"UpsellCard",()=>$self.settings.store.hideUpsellCard?()=>null:$1',
+                match: /"UpsellCard",0,/,
+                replace: '"UpsellCard",0,$self.settings.store.hideUpsellCard?()=>null:',
             },
         },
         {
-            find: '"UpsellSuperGrokSmall",()=>',
+            find: '"UpsellSuperGrokSmall",0,',
             all: true,
             replacement: {
-                match: /"UpsellSuperGrokSmall",\(\)=>(\i)/,
-                replace: '"UpsellSuperGrokSmall",()=>$self.settings.store.hideUpsellSmall?()=>null:$1',
+                match: /"UpsellSuperGrokSmall",0,/,
+                replace: '"UpsellSuperGrokSmall",0,$self.settings.store.hideUpsellSmall?()=>null:',
             },
         },
         // replaces upgrade/try free button (imagine page, sidebar, new chat)
         {
-            find: '"UpsellButton",()=>',
+            find: '"UpsellButton",0,',
             replacement: {
-                match: /"UpsellButton",\(\)=>(\i)/,
-                replace: '"UpsellButton",()=>$self.settings.store.hideUpsellSmall?()=>null:$1',
+                match: /"UpsellButton",0,/,
+                replace: '"UpsellButton",0,$self.settings.store.hideUpsellSmall?()=>null:',
             },
         },
         {
@@ -93,11 +93,11 @@ export default definePlugin({
             },
         },
         {
-            find: '"BrowserNotificationBanner",()=>',
+            find: '"BrowserNotificationBanner",0,',
             all: true,
             replacement: {
-                match: /"BrowserNotificationBanner",\(\)=>(\i)/,
-                replace: '"BrowserNotificationBanner",()=>$self.settings.store.hideNotificationBanner?()=>null:$1',
+                match: /"BrowserNotificationBanner",0,/,
+                replace: '"BrowserNotificationBanner",0,$self.settings.store.hideNotificationBanner?()=>null:',
             },
         },
         // hides upsell card and locked modes in the mode selector

--- a/src/plugins/consoleJanitor/index.ts
+++ b/src/plugins/consoleJanitor/index.ts
@@ -15,7 +15,7 @@ export default definePlugin({
     authors: [Devs.Prism],
 
     patches: [
-        { find: "x.ai/careers", replacement: { match: /console\.info\("[^"]{0,2000}"\)/, replace: "void 0" } },
+        { find: "x.ai/careers", replacement: { match: /console\.info\(`[^`]{0,2000}`\)/, replace: "void 0" } },
         { find: "useDrawerContext must be used within a Drawer.Root", all: true, replacement: warnNoop },
         { find: 'displayName="DialogFooter"', all: true, replacement: warnNoop },
         { find: "pressure_observer", replacement: { match: /if\(!window\.PressureObserver\)return/, replace: "return" } },


### PR DESCRIPTION
## Fixed
- **ContextMenuAPI** clone/edit chat broken. Regex hit both jsx call site and function param destructure, injected `arguments[0]` into destructure pattern, strict mode parse error reverted whole group. Added `(?!\{)` lookahead.
- **Settings** custom instructions tab missing. `DialogOverlay` export shape changed from `"DialogOverlay",()=>X` to `var D="DialogOverlay",...`. New anchor.
- **BetterImagine** ctrl/meta click + multiselect filename. Param renamed, filename moved from `.concat()` to backtick template.
- **Cleaner** upsell banners showing. Turbopack switched indirect exports from `"Name",()=>X` to `"Name",0,fn` for UpsellCard, UpsellSuperGrokSmall, UpsellButton, BrowserNotificationBanner.
- **ConsoleJanitor** x.ai banner. Now backtick template, not double-quoted.
- **ChatBarButtonAPI** paddingInlineEnd. Ternary collapsed from chained to single.
- **NoTelemetry** mixpanel/statsig/log_metric. Functions became anonymous in `e.s(..,0,fn)` exports, `sendBatchLogEvent` became class field, log_metric moved to module 603814 so split into own patch.

## Changed
- **Reporter** `findByProps`/`exportedComponent` finders now recognize turbopack indirect export shape `"X",0,`. 45 false-positive finder errors gone.

## Stats
- patches 43/43 passing
- finders 82/82 passing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes drifted patches and updates our finders to support the new Turbopack indirect export shape, restoring broken UI hooks and removing noisy finder errors. All affected plugins now patch against current builds without regressions.

- **Bug Fixes**
  - Context menu: restore clone/edit chat (added safe lookahead to avoid strict-mode parse errors).
  - Settings: bring back Custom Instructions tab (updated `DialogOverlay` anchor).
  - BetterImagine: fix ctrl/meta-click navigation and filename generation after param/template changes.
  - Cleaner: hide upsell components again by matching Turbopack `"Name",0,fn` export shape.
  - ConsoleJanitor: silence x.ai banner with template literal match.
  - ChatBarButtonAPI: correct paddingInlineEnd patch.
  - NoTelemetry: neutralize mixpanel/statsig/log_metric with new anonymous/class-field export shapes.

- **Refactors**
  - Reporter `findByProps`/`exportedComponent` now detect Turbopack `"X",0,` indirect exports, removing 45 false-positive finder errors.
  - Status: patches 43/43 passing; finders 82/82 passing.

<sup>Written for commit b27ac413c5847777fdc2c75b402230016bbef488. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

